### PR TITLE
Update 2013_05_06_140325_create_local_account_throttle_table.php

### DIFF
--- a/src/migrations/2013_05_06_140325_create_local_account_throttle_table.php
+++ b/src/migrations/2013_05_06_140325_create_local_account_throttle_table.php
@@ -30,6 +30,6 @@ class CreatelocalAccountThrottleTable extends Migration {
 	*/
 	public function down()
 	{
-	Schema::drop('throttle');
+	Schema::drop('local_account_throttle');
 	}
 }


### PR DESCRIPTION
Reversing the migration will not work as down method tries to drop "throttle" table instead of "local_account_throttle"
