### PR TITLE
Update CamelotAuthServiceProvider.php

### DIFF
--- a/src/T4s/CamelotAuth/CamelotAuthServiceProvider.php
+++ b/src/T4s/CamelotAuth/CamelotAuthServiceProvider.php
@@ -48,7 +48,8 @@ class CamelotAuthServiceProvider extends ServiceProvider {
 
 		if($this->app->environment() !== 'production')
 		{
-			define('ENVIRONMENT', 'development');
+			if (!defined('ENVIRONMENT'))
+				define('ENVIRONMENT', 'development');
 		}
 
 		//Camelot::setEventDispatcher(new LaravelDispatcher);


### PR DESCRIPTION
It is necessary to verify the existance of ENVIRONMENT constant in order to run unit tests properly.

1) UploadHelperTest::testSaveNewFile
ErrorException: Constant ENVIRONMENT already defined

C:\wamp\www\sample_domain\laravel\vendor\t4s\camelot-auth\src\T4s\CamelotAuth\CamelotAuthServiceProvider.php:56
C:\wamp\www\sample_domain\laravel\vendor\laravel\framework\src\Illuminate\Foundation\Application.php:318
C:\wamp\www\sample_domain\laravel\vendor\laravel\framework\src\Illuminate\Foundation\ProviderRepository.php:82
C:\wamp\www\sample_domain\laravel\vendor\laravel\framework\src\Illuminate\Foundation\start.php:210
C:\wamp\www\sample_domain\laravel\bootstrap\start.php:62
C:\wamp\www\sample_domain\laravel\app\tests\TestCase.php:16
C:\wamp\www\sample_domain\laravel\vendor\laravel\framework\src\Illuminate\Foundation\Testing\TestCase.php:42
C:\wamp\www\sample_domain\laravel\vendor\laravel\framework\src\Illuminate\Foundation\Testing\TestCase.php:31
C:\wamp\bin\php\php5.4.12\pear\PHPUnit\TextUI\Command.php:176
C:\wamp\bin\php\php5.4.12\pear\PHPUnit\TextUI\Command.php:129
