### PR TITLE
Allow package to be used with both Laravel 4.1 and Laravel 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
     "require": {
         "php": ">=5.3.0",
         "ircmaxell/password-compat": "1.0.*",
-        "illuminate/support": "4.1.*"
+        "illuminate/support": "4.x"
     },
     "require-dev":{
         "mockery/mockery":"dev-master",
         "phpunit/phpunit":"3.7.*",
         "kodova/hamcrest-php": "dev-master",
 
-        "illuminate/cookie": "4.1.*",
-        "illuminate/session": "4.1.*"
+        "illuminate/cookie": "4.x",
+        "illuminate/session": "4.x"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I have changed the Laravel reference to 4.x, so that the package can be used with both Laravel 4.1 and Laravel 4.2
